### PR TITLE
index.jsonへのURLをvpm.mimylab.comに置き換える

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 
 VCC(VRChat Creator Companion)をインストール済みの場合、以下の**どちらか一つ**の手順を行うことでインポートできます。
 
-- https://vpm.mimylab.com/ へアクセスし、「Add to VCC」から`https://mimyquality.github.io/VPM-Repository/index.json`を追加
-- VCCのウィンドウで`Setting - Packages - Add Repository`の順に開き、`https://mimyquality.github.io/VPM-Repository/index.json`を追加
+- https://vpm.mimylab.com/ へアクセスし、「Add to VCC」から`https://vpm.mimylab.com/index.json`を追加
+- VCCのウィンドウで`Setting - Packages - Add Repository`の順に開き、`https://vpm.mimylab.com/index.json`を追加
 
 
 [VPM CLI](https://vcc.docs.vrchat.com/vpm/cli/)を使用してインポートする場合、コマンドラインを開き以下のコマンドを入力してください。
 
 ```
-vpm add repo https://mimyquality.github.io/VPM-Repository/index.json
+vpm add repo https://vpm.mimylab.com/index.json
 ```

--- a/source.json
+++ b/source.json
@@ -1,7 +1,7 @@
 {
     "name": "MimyLab",
     "id": "com.mimylab.vpm",
-    "url": "https://mimyquality.github.io/VPM-Repository/index.json",
+    "url": "https://vpm.mimylab.com/index.json",
     "author": {
         "email": "mimyquality@gmail.com",
         "name": "Mimy Quality",


### PR DESCRIPTION
常に https://vpm.mimylab.com/index.json にリダイレクトされるのでそれに置き換えました。

もしほかのホスティングサービスに移動した際の問題も少なくなるためわたしは https://vpm.mimylab.com/index.json のほうがいいと考えます